### PR TITLE
Add grabFrame and imageType/imageQuality to MediaStreamImageCapture

### DIFF
--- a/AppSrc/MediaStreamImageCaptureDemo.wo
+++ b/AppSrc/MediaStreamImageCaptureDemo.wo
@@ -36,7 +36,7 @@ Object oMediaStreamImageCaptureDemo is a cWebView
         Set pbServerOnDisconnect to True
         Set pbServerOnError to True
         Set pbServerOnPhoto to True
-        
+        Set pbServerOnFrame to True
         
         // This can be any cMediaStream object with a video track
         Object oUserMediaStreamAPI is a cUserMediaStreamAPI
@@ -81,6 +81,13 @@ Object oMediaStreamImageCaptureDemo is a cWebView
             // For a quick display of a single image, we could use sDataURL, but for multiple large images, that'll perform very badly,
             // so ShowImage will save the file (from ucData) instead and create a download URL for it
             Send CloseCamera
+            Send ShowImage sMimeType ucData
+        End_Procedure
+        
+        Procedure OnFrame String sMimeType UChar[] ucData String sDataURL Integer iWidth Integer iHeight
+            Send Log of oLogger (SFormat("Received %1 bytes, mime: %2, width: %3, height: %4", SizeOfArray(ucData), sMimeType, iWidth, iHeight))
+            
+            // When grabbing a frame, we don't close the camera
             Send ShowImage sMimeType ucData
         End_Procedure
     End_Object
@@ -140,9 +147,9 @@ Object oMediaStreamImageCaptureDemo is a cWebView
             Set psCaption to "Camera view"
             Set piColumnCount to 12   
             Set pbFillHeight to True
-            Set pbRender to False
             Set pbShowBorder to False
             Set pbShowCaption to False
+            Set pbRender to False
     
             Object oVideo is a cWebHtmlBox
                 Set psHtml to '<video style="width: 100%" id="my-video-element"></video>'
@@ -178,17 +185,33 @@ Object oMediaStreamImageCaptureDemo is a cWebView
             End_Object
             
             Object oBtnSettings is a cWebButton
-                Set piColumnSpan to 4
+                Set piColumnSpan to 3
                 Set psCaption to "Settings"
                 
                 Procedure OnClick
                     Send Show of oWebSettingsPanel
                 End_Procedure
             End_Object
+            
+            Object oBtnGrabFrame is a cWebButton
+                Set piColumnIndex to 3
+                Set piColumnSpan to 3
+                Set psCaption to "Grab frame"
+                
+                Procedure OnClick
+                    String sImageType
+                    Integer iImageQuality
+                    
+                    WebGet psValue of oWebComboImageType to sImageType
+                    WebGet piSliderValue of oWebSliderImageQuality to iImageQuality
+                    
+                    Send GrabFrame of oMediaStreamImageCaptureAPI sImageType (iImageQuality / 100.0)
+                End_Procedure
+            End_Object
     
             Object oBtnTakePhoto is a cWebButton
-                Set piColumnIndex to 4
-                Set piColumnSpan to 4
+                Set piColumnIndex to 6
+                Set piColumnSpan to 3
                 Set psCaption to "Take photo"
             
                 Procedure OnClick
@@ -205,8 +228,8 @@ Object oMediaStreamImageCaptureDemo is a cWebView
             End_Object
             
             Object oBtnDisconnect is a cWebButton
-                Set piColumnIndex to 8
-                Set piColumnSpan to 4
+                Set piColumnIndex to 9
+                Set piColumnSpan to 3
                 Set psCaption to "Close"
                 
                 Procedure OnClick
@@ -222,6 +245,42 @@ Object oMediaStreamImageCaptureDemo is a cWebView
                 Set phoFloatByControl to oBtnSettings
                 Set pbHideOnBlur to True
         
+                Object oGrabFrameLabel is a cWebLabel
+                    Set piColumnSpan to 0
+                    Set psCaption to "For 'Grab Frame':"
+                End_Object
+                
+                Object oWebComboImageType is a cWebCombo
+                    Set piColumnSpan to 6
+                    Set psLabel to "Image type"
+                    Set peLabelPosition to lpTop
+                    
+                    Procedure OnFill
+                        Send AddComboItem "" "Default"
+                        Send AddComboItem "image/png" "PNG"
+                        Send AddComboItem "image/jpeg" "JPEG"
+                        Send AddComboItem "image/webp" "WEBP"
+                    End_Procedure
+                End_Object
+                
+                Object oWebSliderImageQuality is a cWebSlider
+                    Set piColumnIndex to 6
+                    Set piColumnSpan to 6
+                    Set pbShowValue to True
+                    Set peLabelPosition to lpTop
+                    Set psLabel to "Image quality in %"
+                    Set pbShowMarkers to True
+                    Set piMinValue to 50
+                    Set piMaxValue to 100
+                    Set piInterval to 5
+                    Set piSliderValue to 85
+                End_Object
+                
+                Object oTakePhotoLabel is a cWebLabel
+                    Set piColumnSpan to 0
+                    Set psCaption to "For 'Take Photo':"
+                End_Object
+                
                 Object oWebComboFillLightMode is a cWebCombo
                     Set piColumnSpan to 6
                     Set psLabel to "Fill light mode"
@@ -340,6 +399,7 @@ Object oMediaStreamImageCaptureDemo is a cWebView
                         End
                     End_Procedure
                 End_Object
+                
             End_Object
         End_Object
 

--- a/AppSrc/cMediaStreamImageCaptureAPI.pkg
+++ b/AppSrc/cMediaStreamImageCaptureAPI.pkg
@@ -53,6 +53,10 @@ Class cMediaStreamImageCaptureAPI is a cWebObject
         { WebProperty=Client Category="Client events" }
         Property String psClientOnError ""
         { WebProperty=Client Category="Server events" }
+        Property Boolean pbServerOnFrame False
+        { WebProperty=Client Category="Client events" }
+        Property String psClientOnFrame ""
+        { WebProperty=Client Category="Server events" }
         Property Boolean pbServerOnPhoto False
         { WebProperty=Client Category="Client events" }
         Property String psClientOnPhoto ""
@@ -69,6 +73,7 @@ Class cMediaStreamImageCaptureAPI is a cWebObject
         WebPublishProcedure OnConnectProxy
         WebPublishProcedure OnDisconnect
         WebPublishProcedure OnError
+        WebPublishProcedure OnFrameProxy
         WebPublishProcedure OnPhotoProxy
     End_Procedure
     
@@ -116,6 +121,20 @@ Class cMediaStreamImageCaptureAPI is a cWebObject
         Send ClientAction "applyConstraint" aParams
     End_Procedure
     
+    // Capture a single video frame from the media stream, triggering OnFrame with the result
+    // sImageType (optional): MIME type of the output image, e.g. "image/png" (default) or "image/jpeg"
+    // nImageQuality (optional): Quality for lossy formats, 0.0–1.0 (e.g. 0.9 for JPEG)
+    Procedure GrabFrame String sImageType Number nImageQuality
+        String[] aParams
+        If (num_arguments > 0) Begin
+            Move sImageType to aParams[0]
+        End
+        If (num_arguments > 1) Begin
+            Move nImageQuality to aParams[1]
+        End
+        Send ClientAction "grabFrame" aParams
+    End_Procedure
+
     // Capture an image from the media stream, triggering OnPhoto with the result
     // All arguments are optional
     Procedure TakePhoto Integer eFillLightMode Integer iImageHeight Integer iImageWidth Boolean bRedEyeReduction
@@ -167,6 +186,25 @@ Class cMediaStreamImageCaptureAPI is a cWebObject
     Procedure OnError String sErrorName String sErrorMessage
     End_Procedure
     
+    { Visibility=Private }
+    Procedure OnFrameProxy String sDataURL Integer iWidth Integer iHeight
+        Integer iPos
+        String sMimeType
+        UChar[] ucBase64 ucBinary
+        
+        Move (Pos(";base64,", sDataURL, 1, 100)) to iPos
+        Move (Mid(sDataURL, iPos - 6, 6)) to sMimeType
+        Move (StringToUCharArray(Mid(sDataURL, Length(sDataURL), iPos + 8))) to ucBase64
+        Get Base64DecodeUCharArray of oCharTranslate ucBase64 to ucBinary
+        
+        Send OnFrame sMimeType ucBinary sDataURL iWidth iHeight
+    End_Procedure
+    
+    { MethodType=Event }
+    Procedure OnFrame String sMimeType UChar[] ucData String sDataURL Integer iWidth Integer iHeight
+        // Note that the client-side version of this event receives a single ImageBitmap argument instead
+    End_Procedure
+
     { Visibility=Private }
     Procedure OnPhotoProxy String sDataURL Integer iWidth Integer iHeight
         Integer iPos

--- a/src/mediastream-image-capture.js
+++ b/src/mediastream-image-capture.js
@@ -26,6 +26,7 @@ export default class MediaStreamImageCapture extends df.WebObject {
         this.event('OnConnect', df.cCallModeDefault, 'OnConnectProxy');
         this.event('OnDisconnect');
         this.event('OnError');
+        this.event('OnFrame', df.cCallModeDefault, 'OnFrameProxy');
         this.event('OnPhoto', df.cCallModeDefault, 'OnPhotoProxy');
     }
 
@@ -94,6 +95,38 @@ export default class MediaStreamImageCapture extends df.WebObject {
         }
     }
 
+    async grabFrame(imageType, imageQuality) {
+        if (this.#capture) {
+            try {
+                const bitmap = await this.#capture.grabFrame();
+                let cancelled = false;
+
+                // Fire client-side event with the ImageBitmap
+                this.fireEx({
+                    sEvent: 'OnFrame',
+                    aParams: [bitmap],
+                    bSkipServer: true,
+                    fHandler: oEvent => cancelled = oEvent.bCanceled
+                });
+
+                if (!cancelled && this.pbServerOnFrame) {
+                    // Convert to blob via OffscreenCanvas (width/height are always available from ImageBitmap)
+                    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+                    canvas.getContext('2d').drawImage(bitmap, 0, 0);
+                    const type = (imageType !== undefined && imageType !== '') ? imageType : undefined;
+                    const quality = (imageQuality !== undefined && imageQuality !== '') ? this.#parseNumber(imageQuality) : undefined;
+                    const blob = await canvas.convertToBlob({ type, quality });
+                    const dataUrl = await readBlob(blob);
+                    this.fireEx({ sEvent: 'OnFrame', aParams: [dataUrl, bitmap.width, bitmap.height], bSkipClient: true });
+                }
+
+                bitmap.close();
+            } catch (error) {
+                this.fire('OnError', [error.name, error.message]);
+            }
+        }
+    }
+
     async takePhoto(fillLightMode, imageHeight, imageWidth, redEyeReduction) {
         if (this.#capture) {
             const settings = {};
@@ -158,5 +191,9 @@ export default class MediaStreamImageCapture extends df.WebObject {
         this.#capture = null;
         this.#capabilities = null;
         this.fire('OnDisconnect');
+    }
+
+    #parseNumber(value) {
+        return df.sys.data.stringToNum(value, this.getWebApp().psDecimalSeparator);
     }
 }


### PR DESCRIPTION
## Summary

Adds an enhancement to `cMediaStreamImageCaptureAPI` / `MediaStreamImageCapture`:

### `GrabFrame` — capture a raw video frame

`grabFrame()` uses `ImageCapture.grabFrame()` to snapshot the current video frame as an `ImageBitmap` — no shutter, no flash, very fast. Useful for QR/barcode scanning, motion detection, or any lightweight frame-grab scenario that doesn't need a full photo.

- **Client-side `OnFrame`** receives the raw `ImageBitmap` directly
- **Server-side `OnFrame`** receives the same decoded `sMimeType / ucData / sDataURL / iWidth / iHeight` form as `OnPhoto`; the frame is rendered to an `OffscreenCanvas` and converted to a blob before delivery
- Width and height are always included (they come free from `ImageBitmap`, no extra work required)
- Optional `sImageType` (default `"image/png"`) and `nImageQuality` parameters control the output format

**New DataFlex API:**
```dataflex
Send GrabFrame of oMediaStreamImageCaptureAPI                           // PNG output
Send GrabFrame of oMediaStreamImageCaptureAPI "image/jpeg" 0.85         // JPEG at 85% quality

Procedure OnFrame String sMimeType UChar[] ucData String sDataURL Integer iWidth Integer iHeight
```