### PR TITLE
feat!: Enhanced events

### DIFF
--- a/AppSrc/ContactPickerDemo.wo
+++ b/AppSrc/ContactPickerDemo.wo
@@ -8,6 +8,7 @@ Use cWebCheckBox.pkg
 Use cWebButton.pkg
 Use cWebHtmlBox.pkg
 Use cWebLabel.pkg
+Use cLogger.pkg
 
 Use cContactPickerAPI.pkg
 
@@ -24,8 +25,16 @@ Object oContactPickerDemo is a cWebView
     Set pbServerOnShow to True
     
     Object oContactPickerAPI is a cContactPickerAPI
-        Procedure OnSelect String sJsonData
-            Send ShowInfoBox sJsonData
+        Procedure OnSelect tContactPickerContact[] aContacts
+            Handle hoJson
+            String sJson
+            
+            Get Create (RefClass(cJsonObject)) to hoJson
+            Set peWhiteSpace of hoJson to jpWhitespace_Pretty
+            Send DataTypeToJson of hoJson aContacts
+            Get Stringify of hoJson to sJson
+            Send Log of oLogger (SFormat("Selected: %1", sJson))
+            Send Destroy of hoJson
         End_Procedure
     End_Object
 
@@ -110,6 +119,9 @@ Object oContactPickerDemo is a cWebView
                 
                 Send Select of oContactPickerAPI stData
             End_Procedure
+        End_Object
+        
+        Object oLogger is a cLogger
         End_Object
         
     End_Object 

--- a/AppSrc/NetworkInformationDemo.wo
+++ b/AppSrc/NetworkInformationDemo.wo
@@ -3,6 +3,7 @@ Use cWebPanel.pkg
 Use cWebLabel.pkg
 Use cWebHtmlBox.pkg
 Use cLogger.pkg
+Use cWebButton.pkg
 
 Use cNetworkInformationAPI.pkg
 
@@ -19,26 +20,8 @@ Object oNetworkInformationDemo is a cWebView
     Set pbServerOnShow to True
     
     Object oNetworkInformation is a cNetworkInformationAPI
-        Procedure OnChange
-            Send LogState "Network changed to"
-        End_Procedure
-        
-        Procedure LogState String sLabel
-            Number nDownlink
-            Number nDownlinkMax
-            String sEffectiveType
-            Integer iRTT
-            Boolean bSaveData
-            String sType
-            
-            WebGet pnDownlink to nDownlink
-            WebGet pnDownlinkMax to nDownlinkMax
-            WebGet psEffectiveType to sEffectiveType
-            WebGet piRTT to iRTT
-            WebGet pbSaveData to bSaveData
-            WebGet psType to sType
-            
-            Send Log of oLogger (SFormat("%1: dl = %2, dl-max = %3, et = %4, rtt = %5, sd = %6, type = %7", sLabel, nDownlink, nDownlinkMax, sEffectiveType, iRTT, bSaveData, sType))
+        Procedure OnChange tNetworkInfo stInfo
+            Send Log of oLogger (SFormat("Current info: dl = %1 Mbps, dl-max = %2 Mbps, et = %3, rtt = %4 ms, sd = %5, type = %6", stInfo.downlink, stInfo.downlinkMax, stInfo.effectiveType, stInfo.rtt, stInfo.saveData, stInfo.type))
         End_Procedure
     End_Object
 
@@ -60,6 +43,15 @@ Object oNetworkInformationDemo is a cWebView
             Set psCaption to "If supported, network information status will be shown below. Try throttling network on the Network tab of DevTools if on a desktop browser, or changing your connection if on a mobile device."
             Set piColumnSpan to 0
         End_Object
+        
+        Object oBtnUpdate is a cWebButton
+            Set psCaption to "Update"
+            Set piColumnSpan to 3
+            
+            Procedure OnClick
+                Send Update of oNetworkInformation
+            End_Procedure
+        End_Object
 
         Object oLogger is a cLogger
         End_Object
@@ -74,8 +66,6 @@ Object oNetworkInformationDemo is a cWebView
         If (bIsSupported) Begin
             WebSet psCaption of oWebLabel to "Network Information API is supported"
             WebSet psTextColor of oWebLabel to "green"
-
-            Send LogState of oNetworkInformation "Initial network"
         End
         Else Begin
             WebSet psCaption of oWebLabel to "Network Information API is NOT supported (try Chrome, Edge or Opera)"

--- a/AppSrc/cContactPickerAPI.pkg
+++ b/AppSrc/cContactPickerAPI.pkg
@@ -5,6 +5,28 @@ Struct tContactPickerSelectData
     Boolean bMultiple
 End_Struct
 
+Struct tContactPickerContactAddress
+    String[] addressLine
+    String country
+    String city
+    String dependentLocality
+    String organization
+    String phone
+    String postalCode
+    String recipient
+    String region
+    String sortingCode
+End_Struct
+
+Struct tContactPickerContact
+    { Name = "address" }
+    tContactPickerContactAddress[] Address
+    String[] email
+    String[] icon
+    String[] name
+    String[] tel
+End_Struct
+
 Class cContactPickerAPI is a cWebObject
     
     Procedure Construct_Object
@@ -26,7 +48,7 @@ Class cContactPickerAPI is a cWebObject
     Procedure End_Construct_Object
         Forward Send End_Construct_Object
 
-        WebPublishProcedure OnSelect
+        WebPublishProcedure OnSelectProxy
     End_Procedure
     
     Procedure Select tContactPickerSelectData stData
@@ -41,8 +63,18 @@ Class cContactPickerAPI is a cWebObject
         Send Destroy of hoJson
     End_Procedure
     
+    { Visibility=Private }
+    Procedure OnSelectProxy
+        Handle hoJson
+        tContactPickerContact[] aContacts
+        Get phoActionJsonData to hoJson
+        Set pbRequireAllMembers of hoJson to False
+        Get JsonToDataType of hoJson to aContacts
+        Send OnSelect aContacts
+    End_Procedure
+    
     { MethodType=Event }
-    Procedure OnSelect String sJsonData
+    Procedure OnSelect tContactPickerContact[] aContacts
     End_Procedure
 
 End_Class

--- a/AppSrc/cNetworkInformationAPI.pkg
+++ b/AppSrc/cNetworkInformationAPI.pkg
@@ -14,26 +14,28 @@ Define NI_CONNECTION_TYPE_WIMAX for "wimax"
 Define NI_CONNECTION_TYPE_OTHER for "other"
 Define NI_CONNECTION_TYPE_UNKNOWN for "unknown"
 
+Struct tNetworkInfo
+    // Bandwidth estimate, Mbit/s
+    Number downlink
+    // Maximum downlink speed, Mbit/s
+    Number downlinkMax
+    // Effective connection type, NI_EFFECTIVE_CONNECTION_TYPE_*
+    String effectiveType
+    // Round trip time, ms
+    Integer rtt
+    // Reduced data usage active
+    Boolean saveData
+    // Connection type, NI_CONNECTION_TYPE_*
+    String type
+End_Struct
+
 Class cNetworkInformationAPI is a cWebObject
     
     Procedure Construct_Object
         Forward Send Construct_Object
 
-        // These are all read-only
         { WebProperty=Client DesignTime=False }
         Property Boolean pbIsSupported False
-        { WebProperty=Client DesignTime=False }
-        Property Number pnDownlink 0
-        { WebProperty=Client DesignTime=False }
-        Property Number pnDownlinkMax 0
-        { WebProperty=Client DesignTime=False }
-        Property String psEffectiveType "" // NI_EFFECTIVE_CONNECTION_TYPE_*
-        { WebProperty=Client DesignTime=False }
-        Property Integer piRTT 0
-        { WebProperty=Client DesignTime=False }
-        Property Boolean pbSaveData False
-        { WebProperty=Client DesignTime=False }
-        Property String psType "" // NI_CONNECTION_TYPE_*
 
         { WebProperty=Client }
         Property Boolean pbServerOnChange True
@@ -46,11 +48,27 @@ Class cNetworkInformationAPI is a cWebObject
     Procedure End_Construct_Object
         Forward Send End_Construct_Object
 
-        WebPublishProcedure OnChange
+        WebPublishProcedure OnChangeProxy
+    End_Procedure
+    
+    Procedure Update
+        Send ClientAction "update"
+    End_Procedure
+    
+    { Visibility=Private }
+    Procedure OnChangeProxy
+        Handle hoJson
+        tNetworkInfo stInfo
+        
+        Get phoActionJsonData to hoJson
+        Set pbRequireAllMembers of hoJson to False
+        Get JsonToDataType of hoJson to stInfo
+        Send OnChange stInfo
     End_Procedure
 
     { MethodType=Event }
-    Procedure OnChange
+    // Called whenever connection changes, or on "Update"
+    Procedure OnChange tNetworkInfo stInfo
     End_Procedure
 
 End_Class

--- a/src/contact-picker.js
+++ b/src/contact-picker.js
@@ -1,9 +1,11 @@
+import { readBlob } from './utils/blob.js';
+
 export default class ContactPicker extends df.WebObject {
     constructor(sName, oParent) {
         super(sName, oParent);
         this.prop(df.tBool, 'pbIsSupported', false);
         this.prop(df.tString, 'psSupportedProperties', '');
-        this.event('OnSelect', df.cCallModeDefault);
+        this.event('OnSelect', df.cCallModeDefault, 'OnSelectProxy');
     }
 
     async create(tDef) {
@@ -21,6 +23,9 @@ export default class ContactPicker extends df.WebObject {
             params.aProperties,
             { multiple: params.bMultiple }
         );
-        this.fire('OnSelect', [JSON.stringify(result)]);
+        for (const contact of result?.filter(item => item.icon)) {
+            contact.icon = await Promise.all(contact.icon.map(item => readBlob(item)))
+        }
+        this.fireEx({ sEvent: 'OnSelect', tActionData: result });
     }
 }

--- a/src/contact-picker.js
+++ b/src/contact-picker.js
@@ -23,9 +23,11 @@ export default class ContactPicker extends df.WebObject {
             params.aProperties,
             { multiple: params.bMultiple }
         );
-        for (const contact of result?.filter(item => item.icon)) {
-            contact.icon = await Promise.all(contact.icon.map(item => readBlob(item)))
+        if (result) {
+            for (const contact of result.filter(item => item.icon)) {
+                contact.icon = await Promise.all(contact.icon.map(item => readBlob(item)))
+            }
+            this.fireEx({ sEvent: 'OnSelect', tActionData: result });
         }
-        this.fireEx({ sEvent: 'OnSelect', tActionData: result });
     }
 }

--- a/src/network-information.js
+++ b/src/network-information.js
@@ -1,20 +1,8 @@
-function fix(val, def) {
-    return (val !== undefined && val !== Infinity) ? val : def;
-}
-
 export default class NetworkInformation extends df.WebObject {
     constructor(sName, oParent) {
         super(sName, oParent);
         this.prop(df.tBool, 'pbIsSupported', false);
-
-        this.prop(df.tNumber, 'pnDownlink', 0);
-        this.prop(df.tNumber, 'pnDownlinkMax', 0);
-        this.prop(df.tString, 'psEffectiveType', '');
-        this.prop(df.tInt, 'piRTT', 0);
-        this.prop(df.tBool, 'pbSaveData', false);
-        this.prop(df.tString, 'psType', '');
-
-        this.event('OnChange', df.cCallModeDefault);
+        this.event('OnChange', df.cCallModeDefault, 'OnChangeProxy');
     }
 
     create(tDef) {
@@ -22,21 +10,21 @@ export default class NetworkInformation extends df.WebObject {
         this.set('pbIsSupported', 'connection' in navigator);
         if (this.pbIsSupported) {
             this.update();
-            navigator.connection.addEventListener('change', () => {
-                this.update();
-                this.fire('OnChange');
-            });
+            navigator.connection.addEventListener('change', () => this.update());
         }
     }
 
     update() {
         const con = navigator.connection;
-                
-        this.set('pnDownlink', fix(con.downlink, 0));
-        this.set('pnDownlinkMax', fix(con.downlinkMax, 0));
-        this.set('psEffectiveType', fix(con.effectiveType, ''));
-        this.set('piRTT', fix(con.rtt, 0));
-        this.set('pbSaveData', fix(con.saveData, false));
-        this.set('psType', fix(con.type, ''));
+
+        const val = {
+            downlink: con.downlink,
+            downlinkMax: con.downlinkMax,
+            effectiveType: con.effectiveType,
+            rtt: con.rtt,
+            saveData: con.saveData,
+            type: con.type
+        };
+        this.fireEx({ sEvent: 'OnChange', tActionData: val });
     }
 }


### PR DESCRIPTION
## Overview

This PR enhances server event payloads for the Contact Picker and Network Information components by moving from string/no-arg events to structured action data.

It updates both JavaScript wrappers and DataFlex packages, and aligns the demo views with the new event contracts.

## What Changed

- **Contact Picker**
    - `src/contact-picker.js`
        - Event now routes via `OnSelectProxy` and uses `fireEx` with structured `tActionData`
        - Reads `icon` blobs into transferable values before sending action data
    - `AppSrc/cContactPickerAPI.pkg`
        - Added typed structs: `tContactPickerContactAddress`, `tContactPickerContact`
        - Replaced direct event publish with `OnSelectProxy` that converts JSON action data to typed array
        - Event signature changed from `OnSelect String sJsonData` to `OnSelect tContactPickerContact[] aContacts`
    - `AppSrc/ContactPickerDemo.wo`
        - Updated `OnSelect` handling to consume typed contacts
        - Pretty-prints JSON using `cJsonObject` and logs via `cLogger`

- **Network Information**
    - `src/network-information.js`
        - Removed per-property syncing (`pnDownlink`, `pnDownlinkMax`, etc.)
        - Event now routes via `OnChangeProxy` and sends structured `tActionData` with `fireEx`
        - `update()` now emits a single payload object; change listener triggers `update()`
    - `AppSrc/cNetworkInformationAPI.pkg`
        - Added typed struct `tNetworkInfo`
        - Added `Update` method for explicit refresh from server side
        - Replaced direct event publish with `OnChangeProxy` that parses action JSON to typed struct
        - Event signature changed from `OnChange` to `OnChange tNetworkInfo stInfo`
    - `AppSrc/NetworkInformationDemo.wo`
        - Updated event handler to consume `tNetworkInfo`
        - Added **Update** button to manually trigger refresh
        - Removed old initial logging flow based on client-side web properties

## Breaking Changes

This is a **breaking change** for consumers of both APIs:

1. `cContactPickerAPI.OnSelect` now receives `tContactPickerContact[]` instead of JSON `String`.
2. `cNetworkInformationAPI.OnChange` now receives `tNetworkInfo` payload.
3. `cNetworkInformationAPI` no longer exposes the previous read-only web properties (`pnDownlink`, `pnDownlinkMax`, `psEffectiveType`, `piRTT`, `pbSaveData`, `psType`) as the primary event data path.

## Why

- Improves type safety and ergonomics in DataFlex event handlers.
- Removes manual JSON parsing in app code.
- Aligns event flow with richer payload support (`fireEx`/action data).

Closes #19 